### PR TITLE
Convert strings to utf-8 or binary before sending them over the wire

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,6 +77,7 @@ end
 
 task :default => :test
 
+begin
 require 'rake/rdoctask'
 Rake::RDocTask.new do |rdoc|
   if File.exist?('VERSION')
@@ -89,6 +90,8 @@ Rake::RDocTask.new do |rdoc|
   rdoc.title = "bert #{version}"
   rdoc.rdoc_files.include('README*')
   rdoc.rdoc_files.include('lib/**/*.rb')
+end
+rescue LoadError
 end
 
 task :console do

--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -11,7 +11,11 @@ module BERT
         when ::Encoding::ASCII_8BIT
           super
         else
-          write_enc_string data
+          if data.valid_encoding?
+            write_unicode_string data.encode("utf-8")
+          else
+            super data.b
+          end
         end
       end
 
@@ -21,16 +25,6 @@ module BERT
         write_1 UNICODE_STRING
         write_4 data.bytesize
         write_string data
-      end
-
-      def write_enc_string(data)
-        write_1 ENC_STRING
-        write_4 data.bytesize
-        write_string data
-        enc = data.encoding.name
-        write_1 BIN
-        write_4 enc.bytesize
-        write_string enc
       end
 
       def version_header

--- a/test/bert_test.rb
+++ b/test/bert_test.rb
@@ -25,11 +25,17 @@ class BertTest < Test::Unit::TestCase
         assert_equal @ruby, BERT.decode(@bert)
       end
 
-      should "roundtrip string and maintain encoding" do
+      should "roundtrip string and convert to unicode" do
         str = "日本語".encode 'EUC-JP'
         round = BERT.decode(BERT.encode(str))
-        assert_equal str, round
-        assert_equal str.encoding, round.encoding
+        assert_equal str.encode("UTF-8"), round
+      end
+
+      should "invalid encoding should send as binary" do
+        str = "foo\xe2"
+        refute str.valid_encoding?
+        round = BERT.decode(BERT.encode(str))
+        assert_equal str.b, round.b
       end
 
       should "roundtrip binary string" do


### PR DESCRIPTION
It's turning out to be a pain for the client side to accept any
encoding.  This commit ensures that non-utf8 data is transcoded to utf8
or converted to binary before being sent across the wire.

/cc @github/systems-uv @brianmario 
