### PR TITLE
introduce a new buffered writer method

### DIFF
--- a/bench/memsize.rb
+++ b/bench/memsize.rb
@@ -1,0 +1,29 @@
+require 'bert'
+require 'objspace'
+
+large = ["abc" * 1000] * 10000
+
+def write_berp(output, ruby)
+  data = BERT.encode(ruby)
+  output.write([data.bytesize].pack("N"))
+  output.write(data)
+end
+
+def write_berp2(output, ruby)
+  data = BERT.encode_to_buffer(ruby)
+  output.write([data.bytesize].pack("N"))
+  data.write_to output
+end
+
+socket = File.open File::NULL, 'wb' do |f|
+  GC.start; GC.start; GC.start; GC.disable
+
+  before = ObjectSpace.memsize_of_all(String)
+  write_berp f, large
+  p :ORIGINAL => ObjectSpace.memsize_of_all(String) - before
+
+  GC.start; GC.start; GC.start; GC.disable
+  before = ObjectSpace.memsize_of_all(String)
+  write_berp2 f, large
+  p :NEW => ObjectSpace.memsize_of_all(String) - before
+end

--- a/lib/bert/bert.rb
+++ b/lib/bert/bert.rb
@@ -3,6 +3,10 @@ module BERT
     Encoder.encode(ruby)
   end
 
+  def self.encode_to_buffer(ruby)
+    Encoder.encode_to_buffer(ruby)
+  end
+
   def self.decode(bert)
     Decoder.decode(bert)
   end

--- a/lib/bert/encoder.rb
+++ b/lib/bert/encoder.rb
@@ -9,6 +9,11 @@ module BERT
       Encode.encode(complex_ruby)
     end
 
+    def self.encode_to_buffer(ruby)
+      complex_ruby = convert(ruby)
+      Encode.encode_to_buffer(complex_ruby)
+    end
+
     # Convert complex Ruby form in simple Ruby form.
     #   +item+ is the Ruby object to convert
     #

--- a/test/bert_test.rb
+++ b/test/bert_test.rb
@@ -44,6 +44,14 @@ class BertTest < Test::Unit::TestCase
         assert_equal @bert, BERT.encode(@ruby)
       end
 
+      should "encode with buffer" do
+        buf = BERT.encode_to_buffer(@ruby)
+        io = StringIO.new
+        io.set_encoding 'binary'
+        buf.write_to io
+        assert_equal @bert, io.string
+      end
+
       should "ebin" do
         assert_equal @ebin, BERT.ebin(@bert)
       end


### PR DESCRIPTION
This method will buffer writes, but to an array rather than to a
StringIO.  This allows us to calculate the size of the BERT packet that
we're going to send _without_ copying large strings in to a new buffer.
Writes might take a bit more CPU, but will take far less memory.

Allocation difference looks a bit like this:

```
[aaron@TC bert (buffered-write)]$ ruby -I lib bench/memsize.rb 
{:ORIGINAL=>52415702}
{:NEW=>4981285}
```

The new method takes 1/10th the memory to write a BERT packet.

/cc @github/systems-uv @carlosmn 
