### PR TITLE
speed up `write_1` calls

### DIFF
--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -97,18 +97,18 @@ module BERT
     def write_any_raw obj
       case obj
         when Symbol then write_symbol(obj)
+        when String then write_binary(obj)
         when Fixnum, Bignum then write_fixnum(obj)
         when Float then write_float(obj)
         when Tuple then write_tuple(obj)
         when Array then write_list(obj)
-        when String then write_binary(obj)
         else
           fail(obj)
       end
     end
 
     def write_1(byte)
-      out.write([byte].pack("C"))
+      out.write(byte.chr)
     end
 
     def write_2(short)


### PR DESCRIPTION
We don't need to use `pack`, just `chr`.

Before:

```
[aaron@TC bert (write-1-speed)]$ ruby -I lib bench/encode_bench.rb
                    user     system      total        real
BERT tiny       0.020000   0.000000   0.020000 (  0.014491)
BERT small      0.130000   0.000000   0.130000 (  0.140019)
BERT large      0.450000   0.170000   0.620000 (  0.627474)
BERT complex    2.940000   0.020000   2.960000 (  2.981667)
```

After:

```
[aaron@TC bert (write-1-speed)]$ ruby -I lib bench/encode_bench.rb
                    user     system      total        real
BERT tiny       0.010000   0.000000   0.010000 (  0.011318)
BERT small      0.110000   0.000000   0.110000 (  0.110367)
BERT large      0.380000   0.170000   0.550000 (  0.565794)
BERT complex    2.210000   0.020000   2.230000 (  2.243591)
```
