### PR TITLE
Add writev support

### DIFF
--- a/bert.gemspec
+++ b/bert.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "thoughtbot-shoulda"
     s.add_development_dependency "git"
     s.add_development_dependency "rake"
+    s.add_development_dependency "writev"
     s.add_development_dependency "rake-compiler", "~> 0.9.0"
 end

--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -1,3 +1,5 @@
+require 'writev'
+
 module BERT
   class Encode
     include Types
@@ -59,7 +61,13 @@ module BERT
       end
 
       def write_to(io)
-        @buf.each { |x| io.write x }
+        if io.respond_to?(:writev)
+          @buf.each_slice IO::IOV_MAX do |elems|
+            io.writev elems
+          end
+        else
+          @buf.each { |x| io.write x }
+        end
       end
 
       def bytesize


### PR DESCRIPTION
The newer array-based buffer meant much less copying during serialization. This adds support for the `writev` syscall, letting us write up to `IOV_MAX` buffers at a time over the wire. Potentially reducing the number of syscalls made during serialization.

In my benchmarking locally I was seeing improvements in both memory and speed:

**Before**

```
# bundle exec ruby -I lib bench/memsize.rb 
{:ORIGINAL=>52415702}
{:NEW=>4981285}
```

```
Warming up --------------------------------------
            ORIGINAL     2.000  i/100ms
                 NEW     3.000  i/100ms
Calculating -------------------------------------
            ORIGINAL     24.191  (± 4.1%) i/s -    122.000  in   5.052001s
                 NEW     31.772  (± 9.4%) i/s -    159.000  in   5.062028s
```

**After**

```
# bundle exec ruby -I lib bench/memsize.rb 
{:ORIGINAL=>52415702}
{:NEW=>4181085}
```

```
Warming up --------------------------------------
            ORIGINAL     2.000  i/100ms
                 NEW     3.000  i/100ms
Calculating -------------------------------------
            ORIGINAL     23.942  (± 4.2%) i/s -    120.000  in   5.021372s
                 NEW     38.566  (± 5.2%) i/s -    195.000  in   5.068452s
```

Given these aren't _huge_ advantages, I'm curious if this is an approach we'll want to consider.

Thoughts?

/cc @github/gitrpc @github/systems-uv
