### PR TITLE
Don't use a StringIO when encoding data.

### DIFF
--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -62,6 +62,10 @@ module BERT
         @buf.each { |x| io.write x }
       end
 
+      def to_s
+        @buf.join("")
+      end
+
       def bytesize
         @buf.map(&:bytesize).inject :+
       end
@@ -74,11 +78,7 @@ module BERT
     end
 
     def self.encode(data)
-      buf = encode_to_buffer data
-      io = StringIO.new
-      io.set_encoding('binary') if io.respond_to?(:set_encoding)
-      buf.write_to io
-      io.string
+      encode_to_buffer(data).to_s
     end
 
     def self.encode_data(data, io)


### PR DESCRIPTION
When data is encoded to BERT, each individual, encoded result piece is stored inside an Array based Buffer. At the end, each piece is sequentially written out to a StringIO object and the underlying String is returned. Unfortunately, this sequential writing to StringIO causes a lot of growth and reallocation of the internal String object. By calling `#join` on the Buffer's Array, Ruby will allocate a single string that can contain the whole result in a single step.

See benchmarks in https://github.com/github/bert/pull/7#issuecomment-239096180.

---

This is an easy win in reducing memory usage without any noticeable impact on CPU usage. 🎆 
