### PR TITLE
Ruby 2.4 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     git (1.3.0)
+    power_assert (0.4.1)
     rake (12.0.0)
     rake-compiler (0.9.9)
       rake
+    test-unit (3.2.3)
+      power_assert
     thoughtbot-shoulda (2.11.1)
     yajl-ruby (1.3.0)
 
@@ -21,6 +24,7 @@ DEPENDENCIES
   git
   rake
   rake-compiler (~> 0.9.0)
+  test-unit
   thoughtbot-shoulda
   yajl-ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     rake-compiler (0.9.9)
       rake
     thoughtbot-shoulda (2.11.1)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
@@ -25,4 +25,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     git (1.3.0)
-    rake (11.1.2)
+    rake (12.0.0)
     rake-compiler (0.9.9)
       rake
     thoughtbot-shoulda (2.11.1)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the BERT specification at [bert-rpc.org](http://bert-rpc.org).
 Instances of the following Ruby classes will be automatically converted to the
 proper simple BERT type:
 
-* Fixnum
+* Integer
 * Float
 * Symbol
 * Array
@@ -47,12 +47,12 @@ Usage
 -----
 
     require 'bert'
-    
+
     bert = BERT.encode(t[:user, {:name => 'TPW', :nick => 'mojombo'}])
     # => "\203h\002d\000\004userh\003d\000\004bertd\000\004dictl\000\000\
           000\002h\002d\000\004namem\000\000\000\003TPWh\002d\000\004nickm\
           000\000\000\amojomboj"
-    
+
     BERT.decode(bert)
     # => t[:user, {:name=>"TPW", :nick=>"mojombo"}]
 

--- a/bert.gemspec
+++ b/bert.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency "rake"
     s.add_development_dependency "rake-compiler", "~> 0.9.0"
     s.add_development_dependency "yajl-ruby"
+    s.add_development_dependency "test-unit"
 end

--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -98,7 +98,7 @@ module BERT
       case obj
         when Symbol then write_symbol(obj)
         when String then write_binary(obj)
-        when Fixnum, Bignum then write_fixnum(obj)
+        when Integer then write_integer(obj)
         when Float then write_float(obj)
         when Tuple then write_tuple(obj)
         when Array then write_list(obj)
@@ -135,7 +135,7 @@ module BERT
       write_string data
     end
 
-    def write_fixnum(num)
+    def write_integer(num)
       if num >= 0 && num < 256
         write_1 SMALL_INT
         write_1 num


### PR DESCRIPTION
Ruby 2.4 [unifies `Fixnum` and `Bignum` into a single `Integer` class](https://bugs.ruby-lang.org/issues/12005).

As of 2.4, referencing the `Fixnum` or `Bignum` constants directly emits a warning.

This pull request replaces the references to `Fixnum` or `Bignum` with `Integer`.

I've also bumped a few development dependencies to get the test suite up and running. It's currently failing with a few encoding related errors.