### PR TITLE
Make sure we only collect binary encoded strings in our buffer.

### DIFF
--- a/lib/bert/encode.rb
+++ b/lib/bert/encode.rb
@@ -55,7 +55,7 @@ module BERT
       end
 
       def write(str)
-        @buf << str
+        @buf << str.b
       end
 
       def write_to(io)


### PR DESCRIPTION
@charliesome this should fix the issue encountered by you.

---

This changes the internal `Buffer` class to convert all strings written into it to have a binary/raw encoding instead of whatever encoding the string originally had. When the strings get written to the wire their encoding is lost (or transmitted separately in V2 of the protocol) anyway.

---

Non-scientific benchmarks:

Before:

```
$ bundle exec ruby bench/bench.rb 
       user     system      total        real
BERT tiny  0.010000   0.000000   0.010000 (  0.006823)
BERT small  0.060000   0.000000   0.060000 (  0.057645)
BERT large  0.290000   0.110000   0.400000 (  0.406172)
BERT complex  1.150000   0.010000   1.160000 (  1.150710)
```

After:

```
$ bundle exec ruby bench/bench.rb 
       user     system      total        real
BERT tiny  0.010000   0.000000   0.010000 (  0.007411)
BERT small  0.060000   0.000000   0.060000 (  0.064392)
BERT large  0.280000   0.030000   0.310000 (  0.308900)
BERT complex  1.270000   0.000000   1.270000 (  1.273539)
```