### PR TITLE
Remove LOAD_PATH manipulation

### DIFF
--- a/lib/bert.rb
+++ b/lib/bert.rb
@@ -1,8 +1,6 @@
 
 require 'stringio'
 
-$:.unshift File.join(File.dirname(__FILE__), *%w[.. ext])
-
 require 'bert/bert'
 require 'bert/types'
 


### PR DESCRIPTION
ext/ should already be added to the load path by bundler or rubygems since it is in the gemspec.