### PR TITLE
Use shared strings to decrease allocated bytes.

### DIFF
--- a/lib/bert/decode.rb
+++ b/lib/bert/decode.rb
@@ -10,17 +10,19 @@ module BERT
     end
 
     def self.decode(string)
-      io = StringIO.new(string)
-      io.set_encoding('binary') if io.respond_to?(:set_encoding)
-      header = io.getbyte
+      header = string.getbyte(0)
+
       case header
       when VERSION_4
         raise "v4 stream cannot be decoded" unless BERT.supports?(:v4)
-        Mochilo.unpack(io.read)
+        Mochilo.unpack(string.byteslice(1, string.bytesize - 1))
       when VERSION_3
         raise "v3 stream cannot be decoded" unless BERT.supports?(:v3)
-        Mochilo.unpack_unsafe(io.read)
+        Mochilo.unpack_unsafe(string.byteslice(1, string.bytesize - 1))
       when MAGIC, VERSION_2
+        io = StringIO.new(string)
+        io.set_encoding('binary') if io.respond_to?(:set_encoding)
+        io.getbyte
         new(io).read_any
       else
         fail("Bad Magic")


### PR DESCRIPTION
This commit uses string byteslice rather than rb_str_new so that we can
take advantage of Ruby's shared string optimizations.  Since we are
slicing all the way to the end of a buffer, we can use a trick which
lets us share byte buffers between string objects.

Here is the benchmark code:

```ruby
require 'bert'
require 'allocation_tracer'

zeroes = "0" * (1024*1024*50)

BERT::Encode.version = :v4

buf = BERT.encode zeroes

ObjectSpace::AllocationTracer.setup(%i{path line type})

result = ObjectSpace::AllocationTracer.trace do
  5.times { BERT.decode(buf) }
end

p [:file, :line, :type, :bytes]
result.each do |(file, line, type), info|
  p [file, line, type, info.last]
end
```

Here is the output before the change:

```
[aaron@TC-265 bert (slice-instead-of-dup)]$ be ruby -I lib:~/git/allocation_tracer/lib test.rb
[:file, :line, :type, :bytes]
["/Users/aaron/github/bert/lib/bert/decoder.rb", 8, :T_STRING, 209715374]
["/Users/aaron/github/bert/lib/bert/decoder.rb", 8, :T_IMEMO, 0]
```

Here is the output after this patch:

```
[aaron@TC-265 bert (slice-instead-of-dup)]$ be ruby -I lib:~/git/allocation_tracer/lib test.rb
[:file, :line, :type, :bytes]
["/Users/aaron/github/bert/lib/bert/decoder.rb", 8, :T_STRING, 52428961]
["/Users/aaron/github/bert/lib/bert/decoder.rb", 8, :T_IMEMO, 0]
```

Since we share string buffers, the decode method allocates much less
memory.