### PR TITLE
Prepare for frozen strings: mark strings as mutable

### DIFF
--- a/lib/bert/decode.rb
+++ b/lib/bert/decode.rb
@@ -31,7 +31,7 @@ module BERT
 
     def initialize(ins)
       @in = ins
-      @peeked = ""
+      @peeked = +""
     end
 
     def read_any
@@ -66,7 +66,7 @@ module BERT
         length = 0
       else
         result = @peeked
-        @peeked = ''
+        @peeked = +''
         length -= result.length
       end
 


### PR DESCRIPTION
For https://github.com/github/ruby-architecture/issues/949

We are preparing to freeze all strings by default, but are getting frozen string errors from this gem. This PR marks those things as mutable so we no longer get errors.

Example error:

```
"/workspaces/github/vendor/gems/3.3.4/ruby/3.3.0/gems/bert-1.1.10.49.gaa7e3f5/lib/bert/decode.rb:74:in `read': can't modify frozen String: \"\" (FrozenError)\n" +
```